### PR TITLE
Allows passing filters to AzureSearchVectorStoreRetriever

### DIFF
--- a/langchain/vectorstores/azuresearch.py
+++ b/langchain/vectorstores/azuresearch.py
@@ -268,7 +268,7 @@ class AzureSearch(VectorStore):
             List[Document]: A list of documents that are most similar to the query text.
         """
         docs_and_scores = self.vector_search_with_score(
-            query, k=k, filters=kwargs.get("filters", None)
+            query, k=k, filters = ' and '.join(kwargs.get("filters", {}).values())
         )
         return [doc for doc, _ in docs_and_scores]
 
@@ -323,7 +323,7 @@ class AzureSearch(VectorStore):
             List[Document]: A list of documents that are most similar to the query text.
         """
         docs_and_scores = self.hybrid_search_with_score(
-            query, k=k, filters=kwargs.get("filters", None)
+            query, k=k, filters = ' and '.join(kwargs.get("filters", {}).values())
         )
         return [doc for doc, _ in docs_and_scores]
 
@@ -381,7 +381,7 @@ class AzureSearch(VectorStore):
             List[Document]: A list of documents that are most similar to the query text.
         """
         docs_and_scores = self.semantic_hybrid_search_with_score(
-            query, k=k, filters=kwargs.get("filters", None)
+            query, k=k, filters = ' and '.join(kwargs.get("filters", {}).values())
         )
         return [doc for doc, _ in docs_and_scores]
 
@@ -478,6 +478,7 @@ class AzureSearch(VectorStore):
 class AzureSearchVectorStoreRetriever(BaseRetriever, BaseModel):
     vectorstore: AzureSearch
     search_type: str = "hybrid"
+    filters: dict = None
     k: int = 4
 
     class Config:
@@ -501,11 +502,11 @@ class AzureSearchVectorStoreRetriever(BaseRetriever, BaseModel):
         run_manager: CallbackManagerForRetrieverRun,
     ) -> List[Document]:
         if self.search_type == "similarity":
-            docs = self.vectorstore.vector_search(query, k=self.k)
+            docs = self.vectorstore.vector_search(query, k=self.k, filters=self.filters)
         elif self.search_type == "hybrid":
-            docs = self.vectorstore.hybrid_search(query, k=self.k)
+            docs = self.vectorstore.hybrid_search(query, k=self.k, filters=self.filters)
         elif self.search_type == "semantic_hybrid":
-            docs = self.vectorstore.semantic_hybrid_search(query, k=self.k)
+            docs = self.vectorstore.semantic_hybrid_search(query, k=self.k, filters=self.filters)
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")
         return docs


### PR DESCRIPTION
  - Description: Allows passing filters to AzureSearchVectorStoreRetriever, 
  - Issue: https://github.com/hwchase17/langchain/issues/6131,
  - Dependencies: https://github.com/hwchase17/langchain/pull/7154(optional: it allows adding extra sections. it can be done manually through the azure ui as well)
  - @rlancemartin, @eyurtsev @hwchase17, 


Example:
```
filters = {
    "filter1": "document_id eq 'xcf76'",
    "filter2": "document_id ne 'xcf2'"
}

retriever = AzureSearchVectorStoreRetriever(
    vectorstore=vector_store,
    filters = filters,
    k=1)

llm = AzureOpenAI(engine="gpt-35-turbo",
                  model_name="gpt-35-turbo",
                  temperature=0.3)
qa = RetrievalQA.from_chain_type(llm=llm, chain_type="stuff", retriever=retriever, return_source_documents=True,
                                 verbose=True)

res = qa('what is subject x based on')
print(res)```
 